### PR TITLE
Handle absolute paths in hspec-discover with /Users

### DIFF
--- a/src/Database/Persist/Discover/Exe.hs
+++ b/src/Database/Persist/Discover/Exe.hs
@@ -171,7 +171,7 @@ mkModulePieces
     :: FilePath
     -> [String]
 mkModulePieces fp =
-    fmap dropSuffixes $ dropWhile isLowerFirst $ filter noDots $ splitDirectories fp
+    fmap dropSuffixes $ reverse $ takeWhile (not . isLowerFirst) $ reverse $ filter noDots $ splitDirectories fp
   where
     noDots x =
         "." /= x && ".." /= x

--- a/test/Database/Persist/Discover/ExeSpec.hs
+++ b/test/Database/Persist/Discover/ExeSpec.hs
@@ -53,4 +53,13 @@ spec = do
                         , modulePath =
                             exPath
                         }
-
+        it "pathToModule absolute path" do
+            let absPath = "/Users/user/Code/project/src/Foo/Bar.hs"
+            pathToModule absPath
+                `shouldBe`
+                    Just Module
+                        { moduleName =
+                            "Foo.Bar"
+                        , modulePath =
+                            absPath
+                        }


### PR DESCRIPTION
macOS capitalizes a lot of folders, so this messed up mkModulePieces.
For instance,

  /Users/matthewbauer/Code/persistent-discover/src/Foo/Bar.hs

became

  module /.Users.matthewbauer.Code.persistent-discover.src.Foo.Bar

To correct this, we should start in reverse order, so that we go up
the directory list from bottom to top. Then, we take the list while
they are not lower case.