### PR TITLE
Add `TemplateHaskell` pragma to generated module

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,14 @@
 
 ## Unreleased changes
 
+## 0.1.0.5
+
+- Fix a bug where `TemplateHaskell` pragma was not added. [#]()
+
 ## 0.1.0.4
 
 - Fix a bug where non-Haskell files would be picked up and imported in the
-  generated file. [#]()
+  generated file. [#4](https://github.com/parsonsmatt/persistent-discover/pull/4)
 
 ## 0.1.0.3
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 ## 0.1.0.5
 
-- Fix a bug where `TemplateHaskell` pragma was not added. [#]()
+- Fix a bug where `TemplateHaskell` pragma was not added. [#6](https://github.com/parsonsmatt/persistent-discover/pull/6)
 
 ## 0.1.0.4
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                persistent-discover
-version:             0.1.0.4
+version:             0.1.0.5
 github:              "parsonsmatt/persistent-discover"
 license:             BSD3
 author:              "Matt Parsons"

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,9 @@ dependencies:
 - persistent >= 2.13.0.0
 - template-haskell >= 2.16.0.0
 - file-embed
+- discover-instances
+- some-dict-of
+- text
 
 ghc-options:
     - -Wall

--- a/persistent-discover.cabal
+++ b/persistent-discover.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 70e0abec0333022d7bebf1309003385e89b17edbca9f5a474563412285fd737b
+-- hash: 7afb3dfe3b260fc3437dbe3d71ee99ef0309962a4069b97714259c50024348c1
 
 name:           persistent-discover
-version:        0.1.0.4
+version:        0.1.0.5
 synopsis:       Persistent module discover utilities
 description:    This package provides an executable for discovering Persistent model definition files, as well as a library function to glob all persistent model files. Please see the README on GitHub at <https://github.com/parsonsmatt/persistent-discover#readme>
 category:       Web

--- a/persistent-discover.cabal
+++ b/persistent-discover.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 02c55b7bab0afd35d762f5a1f8f30fbab6f0b6c13966145570b5572c2773bdc5
+-- hash: 70e0abec0333022d7bebf1309003385e89b17edbca9f5a474563412285fd737b
 
 name:           persistent-discover
 version:        0.1.0.4
@@ -53,12 +53,15 @@ library
   build-depends:
       base >=4.12 && <5
     , directory
+    , discover-instances
     , dlist
     , file-embed
     , filepath
     , mtl
     , persistent >=2.13.0.0
+    , some-dict-of
     , template-haskell >=2.16.0.0
+    , text
   default-language: Haskell2010
 
 executable persistent-discover
@@ -85,13 +88,16 @@ executable persistent-discover
   build-depends:
       base >=4.12 && <5
     , directory
+    , discover-instances
     , dlist
     , file-embed
     , filepath
     , mtl
     , persistent >=2.13.0.0
     , persistent-discover
+    , some-dict-of
     , template-haskell >=2.16.0.0
+    , text
   default-language: Haskell2010
 
 test-suite persistent-discover-test
@@ -122,6 +128,7 @@ test-suite persistent-discover-test
   build-depends:
       base >=4.12 && <5
     , directory
+    , discover-instances
     , dlist
     , file-embed
     , filepath
@@ -130,5 +137,7 @@ test-suite persistent-discover-test
     , mtl
     , persistent >=2.13.0.0
     , persistent-discover
+    , some-dict-of
     , template-haskell >=2.16.0.0
+    , text
   default-language: Haskell2010

--- a/src/Database/Persist/Discover/Exe.hs
+++ b/src/Database/Persist/Discover/Exe.hs
@@ -126,6 +126,7 @@ renderFile amf = render do
         "{-# LINE 1 "
         fromString $ show modName
         " #-}"
+    "{-# LANGUAGE TemplateHaskell #-}"
     ""
     renderLine do
         "module "

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,3 +7,5 @@ extra-deps:
 packages:
 - .
 - example/
+- ../discover-instances
+- ../some-dict-of

--- a/test/Database/Persist/Discover/ExeSpec.hs
+++ b/test/Database/Persist/Discover/ExeSpec.hs
@@ -1,11 +1,34 @@
 module Database.Persist.Discover.ExeSpec where
 
+import qualified Data.Text as Text
 import Test.Hspec
 import Database.Persist.Discover.Exe
 import System.FilePath
 
 spec :: Spec
 spec = do
+    describe "renderFile" do
+        it "should have TemplateHaskell pragma" do
+            let rendered  =
+                    renderFile AllModelsFile
+                        { amfModuleBase =
+                            Module
+                                { moduleName = "Asdf"
+                                , modulePath = "src/Asdf.hs"
+                                }
+                        , amfModuleImports =
+                            []
+                        }
+                firstLines =
+                    unlines . take 4 . lines $ rendered
+                expected =
+                    render do
+                        "{-# LINE 1 \"Asdf\" #-}"
+                        "{-# LANGUAGE TemplateHaskell #-}"
+                        ""
+                        "module Asdf where"
+            firstLines `shouldBe` expected
+
     describe "Render" do
         it "works" do
             shouldBe


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [-] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [-] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
