### PR TITLE
Import `Control.Monad`

### DIFF
--- a/src/Database/Persist/Discover/Exe.hs
+++ b/src/Database/Persist/Discover/Exe.hs
@@ -33,6 +33,7 @@
 module Database.Persist.Discover.Exe where
 
 import System.FilePath
+import Control.Monad (guard, filterM)
 import Control.Monad.State
 import Data.String
 import Data.DList (DList(..))


### PR DESCRIPTION
mtl-2.3 stops reexporting `Control.Monad` from `Control.Monad.State`